### PR TITLE
NGSTACK-529 update render of image in item preview template with ng_r…

### DIFF
--- a/bundle/Resources/views/app/item/nglayouts_app_preview.html.twig
+++ b/bundle/Resources/views/app/item/nglayouts_app_preview.html.twig
@@ -1,11 +1,13 @@
 {% if content.hasField('image') and not content.fields.image.empty %}
-    {% set image_alias = ng_image_alias(content.fields.image, 'nglayouts_app_preview') %}
-
-    {% if image_alias %}
-        <div class="image">
-            <img src="{{ asset(image_alias.uri) }}" />
-        </div>
-    {% endif %}
+    <div class="image">
+        {{ ng_render_field(
+            content.fields.image, {
+                'parameters': {
+                    'alias': 'nglayouts_app_preview',
+                }
+            }
+        ) }}
+    </div>
 {% endif %}
 
 <div class="name">


### PR DESCRIPTION
This change was made in order to cover rendering both remotemedia field type and image field type with a single template. 

No difference in markup has been done, image is still wrapped inside the ".image" wrapper and no additional html has been generated.